### PR TITLE
The way to publish JS.Class on NPM

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,5 @@
+(function() {
+  var $ = (typeof this.global === 'object') ? this.global : this
+  $.JSCLASS_PATH = 'build/min/'
+})()
+require('./' + JSCLASS_PATH + 'loader')

--- a/package.json
+++ b/package.json
@@ -1,0 +1,24 @@
+{
+  "name": 'js.class',
+  "version": 'edge',
+  "description": "Implementation of the core of Ruby's object system in JavaScript.",
+  "keywords": ['ruby', 'class'],
+  "homepage": "http://jsclass.jcoglan.com/",
+  "people": [
+    {
+      "name": "James Coglan",
+      "url": "http://jcoglan.com"
+    }
+  ],
+  "main": "index",
+  "repository": {
+    "type": "git",
+    "url": "http://github.com/jcoglan/js.class"
+  },
+  "depedencies": {
+    "jake": "0.1.x",
+  },
+  "scripts": {
+    "install": "jake"
+  }
+}


### PR DESCRIPTION
That's a few minute commit that give you the possibility (I didn't made this yet) to publish js.class on NPM. I think that's a good idea to make it more accessible and easy to install on a node environment !
This commit intend to solve the issue #18.
