### PR TITLE
Fix typos in JS.Packages introduction

### DIFF
--- a/site/src/pages/packages/introduction.haml
+++ b/site/src/pages/packages/introduction.haml
@@ -7,8 +7,8 @@
   * @JS.Packages@, the dependency manager
   * A list of dependencies
   
-  You can get @JS.Packages@ either by loading the @pacakge.js@ or @loader.js@
-  into your environment. (@loader.js@ is @pacakge.js@ plus dependency data for
+  You can get @JS.Packages@ either by loading the @package.js@ or @loader.js@
+  into your environment. (@loader.js@ is @package.js@ plus dependency data for
   JS.Class itself; if you just want to use @JS.Packages@ to manage your code
   without using the rest of the JS.Class library, use @package.js@.)
   


### PR DESCRIPTION
Utterly minor.
